### PR TITLE
README for Project Management Docs — Summary of OctoAcme processes & doc links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,34 @@
+# OctoAcme Project Management Docs
+
+Welcome to the centralized hub for OctoAcme's project management knowledge. This README provides a concise overview of our processes and quick links for onboarding, implementation, and continuous improvement.
+
+## Overview of Project Management Processes
+
+OctoAcme follows a structured, repeatable approach to project delivery, rooted in customer-first and iterative principles. Projects progress through five phases: Initiation, Planning, Execution, Release, and Retrospective. Key roles include **Project Managers** who coordinate delivery, manage risks, and facilitate communications; **Product Managers** who define outcomes, prioritize work, and measure success; and **Developers** who design, build, test, and collaborate on quality standards. QA/Testing and Stakeholders are involved throughout to validate quality and provide strategic input.
+
+Work flows through standardized tools such as GitHub Projects boards (with columns: Backlog, Ready, In Progress, In Review, QA, Done) and key artifacts including project charters, roadmaps, sprint backlogs, risk registers, and retrospective notes. This ensures full traceability and accountability. A structured communication cadence—including weekly syncs between Project and Product Managers, twice-weekly standups for delivery teams, monthly stakeholder updates, and standardized templates—promotes transparency and rapid learning.
+
+Quality and risk management are embedded at every phase. Teams implement CI/CD pipelines with mandatory testing gates (unit tests, integration tests, smoke tests, and security scanning), conduct code reviews with approval requirements, and maintain a Risk Register that is reviewed weekly. Blocker escalation follows a tiered approach (team-level → PM → Product Lead → Sponsor), ensuring that issues are surfaced and resolved at the appropriate level. This combination of clear ownership, transparent communication, rigorous quality practices, and continuous improvement through retrospectives enables OctoAcme to deliver reliable, measurable outcomes while minimizing single-person dependency risk.
+
+## Docs Index
+
+- [Project Management Overview](octoacme-project-management-overview.md)
+- [Project Initiation Guide](octoacme-project-initiation.md)
+- [Project Planning](octoacme-project-planning.md)
+- [Execution & Tracking](octoacme-execution-and-tracking.md)
+- [Risk Management & Communication](octoacme-risks-and-communication.md)
+- [Release & Deployment Guide](octoacme-release-and-deployment.md)
+- [Retrospective & Continuous Improvement](octoacme-retrospective-and-continuous-improvement.md)
+- [Roles & Personas](octoacme-roles-and-personas.md)
+
+## Contributing to These Docs
+
+As OctoAcme's practices evolve, please keep this README and all process documents current. When adding new process documentation or updating existing guidance:
+
+1. Create a branch from `main` with a descriptive name (e.g., `docs/add-release-checklist`)
+2. Add or update files in the `docs/` folder
+3. Open a pull request referencing any related issue
+4. Request review from relevant stakeholders or project leads
+5. Merge once approved and incorporate feedback into the living documentation
+
+This collaborative approach ensures that institutional knowledge stays accurate, discoverable, and accessible to all team members.


### PR DESCRIPTION
Closes #2. Adds a centralized README to the docs/ folder that summarizes OctoAcme project management processes and includes index links to all process documents.